### PR TITLE
Changes to Make Addon work on linux platform

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,6 +32,7 @@ class CBB_preferences(bpy.types.AddonPreferences):
     def default_csc_exe_path() -> str:
         csc_path = {
             "Windows": r"C:\Program Files\Cascadeur\cascadeur.exe",
+            "Linux": r"/opt/cascadeur/cascadeur",
         }
         default = csc_path.get(platform.system(), "")
         return default if file_handling.file_exists(default) else ""

--- a/utils/csc_handling.py
+++ b/utils/csc_handling.py
@@ -55,7 +55,6 @@ class CascadeurHandler:
     def execute_csc_command(self, command: str) -> None:
         subprocess.Popen(
             [self.csc_exe_path_addon_preference, command],
-            creationflags=subprocess.CREATE_NEW_CONSOLE,
         )
 
     @property


### PR DESCRIPTION
As per as the suggestions by @arcsikex, the following changes will make addon to work on linux platform

- Added a default cascadeur path to `csc_path` dictionary.

- Removed creation flag `CREATE_NEW_CONSOLE` from `execute_csc_command`

closes #4 