### PR TITLE
Fix for Linux version to work

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Cascadeur Bridge for Blender",
     "author": "Aron Nemeth",
-    "version": (0, 4),
+    "version": (0, 4, 1),
     "blender": (3, 5, 0),
     "location": "View3D > Panels > CSC Bridge",
     "description": "Helps you to integrate Cascadeur to your workflow with Belnder.",

--- a/__init__.py
+++ b/__init__.py
@@ -32,6 +32,7 @@ class CBB_preferences(bpy.types.AddonPreferences):
     def default_csc_exe_path() -> str:
         csc_path = {
             "Windows": r"C:\Program Files\Cascadeur\cascadeur.exe",
+            "Linux": r"/opt/cascadeur/cascadeur",
         }
         default = csc_path.get(platform.system(), "")
         return default if file_handling.file_exists(default) else ""

--- a/operators/csc_ops.py
+++ b/operators/csc_ops.py
@@ -1,5 +1,6 @@
 import bpy
 import os
+import platform
 
 from ..utils import file_handling
 from ..utils.csc_handling import CascadeurHandler
@@ -48,16 +49,17 @@ class CBB_OT_install_required_files(bpy.types.Operator):
             return {"CANCELLED"}
 
         # Copy DLLs
-        dlls_source = os.path.join(ADDON_PATH, "csc_files")
-        dlls_path = os.path.join(ch.csc_dir, "python", "DLLs")
-        result = file_handling.copy_files(
-            dlls_source, dlls_path, ch.required_dlls, overwrite=False
-        )
-        if not result:
-            self.report(
-                {"ERROR"}, "You don't have permission to copy the files for Cascadeur"
+        if platform.system() == "Windows":
+            dlls_source = os.path.join(ADDON_PATH, "csc_files")
+            dlls_path = os.path.join(ch.csc_dir, "python", "DLLs")
+            result = file_handling.copy_files(
+                dlls_source, dlls_path, ch.required_dlls, overwrite=False
             )
-            self.report({"INFO"}, "Restart Blender as Admin and try again")
-            return {"CANCELLED"}
+            if not result:
+                self.report(
+                    {"ERROR"}, "You don't have permission to copy the files for Cascadeur"
+                )
+                self.report({"INFO"}, "Restart Blender as Admin and try again")
+                return {"CANCELLED"}
         self.report({"INFO"}, "All necessary files have been successfully copied")
         return {"FINISHED"}

--- a/operators/fbx_transfer.py
+++ b/operators/fbx_transfer.py
@@ -71,9 +71,11 @@ class CBB_OT_export_blender_fbx(bpy.types.Operator):
     server_socket = None
     file_path = None
 
+    def __del__(self):
+        self.server_socket.close()
+
     def modal(self, context, event):
         if event.type == "ESC":
-            self.server_socket.close()
             return {"CANCELLED"}
 
         self.server_socket.run()
@@ -83,12 +85,10 @@ class CBB_OT_export_blender_fbx(bpy.types.Operator):
             response = self.server_socket.receive_message()
             if response == "SUCCESS":
                 print("File successfully imported to Cascadeur.")
-                self.server_socket.close()
                 file_handling.delete_file(self.file_path)
                 self.report({"INFO"}, "Finished")
                 return {"FINISHED"}
             else:
-                self.server_socket.close()
                 return {"CANCELLED"}
 
         return {"PASS_THROUGH"}
@@ -111,9 +111,11 @@ class CBB_OT_import_cascadeur_fbx(bpy.types.Operator):
 
     server_socket = None
 
+    def __del__(self):
+        self.server_socket.close()
+
     def modal(self, context, event):
         if event.type == "ESC":
-            self.server_socket.close()
             return {"CANCELLED"}
 
         self.server_socket.run()
@@ -125,7 +127,6 @@ class CBB_OT_import_cascadeur_fbx(bpy.types.Operator):
                 file_handling.wait_for_file(data)
                 import_fbx(data)
                 file_handling.delete_file(data)
-                self.server_socket.close()
                 self.report({"INFO"}, "Finished")
                 return {"FINISHED"}
 
@@ -154,9 +155,11 @@ class CBB_OT_import_action_to_selected(bpy.types.Operator):
             and context.active_object.type == "ARMATURE"
         )
 
+    def __del__(self):
+        self.server_socket.close()
+
     def modal(self, context, event):
         if event.type == "ESC":
-            self.server_socket.close()
             return {"CANCELLED"}
 
         self.server_socket.run()
@@ -171,7 +174,6 @@ class CBB_OT_import_action_to_selected(bpy.types.Operator):
                 actions = get_actions_from_objects(imported_objects)
                 apply_action(self.ao, actions[0])
                 delete_objects(imported_objects)
-                self.server_socket.close()
                 self.report({"INFO"}, "Finished")
                 return {"FINISHED"}
 

--- a/utils/csc_handling.py
+++ b/utils/csc_handling.py
@@ -1,4 +1,5 @@
 import subprocess
+import platform
 import os
 
 from . import file_handling
@@ -53,10 +54,13 @@ class CascadeurHandler:
         subprocess.Popen([csc_path])
 
     def execute_csc_command(self, command: str) -> None:
-        subprocess.Popen(
-            [self.csc_exe_path_addon_preference, command],
-            creationflags=subprocess.CREATE_NEW_CONSOLE,
-        )
+        if platform.system() == "Windows":
+            subprocess.Popen(
+                [self.csc_exe_path_addon_preference, command],
+                creationflags=subprocess.CREATE_NEW_CONSOLE,
+            )
+        else:
+            subprocess.Popen([self.csc_exe_path_addon_preference, command])
 
     @property
     def are_commands_installed(self) -> bool:


### PR DESCRIPTION
With the help of @HarshNarayanJha these are the fixes needed for the addon to work on Linux:

- Creation flag for the Popen method is only used on Windows
- Add default path for Linux
- DLL install is skipped on Linux. They are part of the Linux version of Cascadeur by default.
Fixes issue #4 

General fix:
- Close sockets even if the modal operator fails.