### PR TITLE
Task/cascadeur import export options

### DIFF
--- a/csc_files/externals/temp_batch_exporter.py
+++ b/csc_files/externals/temp_batch_exporter.py
@@ -17,7 +17,7 @@ def run(scene):
         scene.error(f"Couldn't create socket. Error: {e}")
         return
     settings_dict = client.receive_message()
-    # TODO: Get export method from message
+    method_name = settings_dict.get("export_method", "export_all_objects")
     export_paths = []
 
     for s in scenes:
@@ -29,8 +29,8 @@ def run(scene):
         )
         export_path = commons.get_export_path(s.name())
         fbx_scene_loader.set_settings(commons.set_export_settings(settings_dict))
-        # TODO: Get export method of fbx scene loader
-        fbx_scene_loader.export_all_objects(export_path)
+        export_method = getattr(fbx_scene_loader, method_name)
+        export_method(export_path)
         export_paths.append(export_path)
         scene.info(f"File exported to {export_path}")
 

--- a/csc_files/externals/temp_batch_exporter.py
+++ b/csc_files/externals/temp_batch_exporter.py
@@ -17,6 +17,7 @@ def run(scene):
         scene.error(f"Couldn't create socket. Error: {e}")
         return
     settings_dict = client.receive_message()
+    # TODO: Get export method from message
     export_paths = []
 
     for s in scenes:
@@ -28,6 +29,7 @@ def run(scene):
         )
         export_path = commons.get_export_path(s.name())
         fbx_scene_loader.set_settings(commons.set_export_settings(settings_dict))
+        # TODO: Get export method of fbx scene loader
         fbx_scene_loader.export_all_objects(export_path)
         export_paths.append(export_path)
         scene.info(f"File exported to {export_path}")

--- a/csc_files/externals/temp_exporter.py
+++ b/csc_files/externals/temp_exporter.py
@@ -24,10 +24,13 @@ def run(scene):
         scene.error(f"Couldn't create socket. Error: {e}")
         return
 
-    settings_dict = client.receive_message()
-    # TODO: Get export method from message
+    settings_dict: dict = client.receive_message()
+
     fbx_scene_loader.set_settings(commons.set_export_settings(settings_dict))
-    fbx_scene_loader.export_all_objects(export_path)
+
+    method_name = settings_dict.get("export_method", "export_all_objects")
+    export_method = getattr(fbx_scene_loader, method_name)
+    export_method(export_path)
     scene.info(f"File exported to {export_path}")
     client.send_message([export_path])
     client.close()

--- a/csc_files/externals/temp_exporter.py
+++ b/csc_files/externals/temp_exporter.py
@@ -25,6 +25,7 @@ def run(scene):
         return
 
     settings_dict = client.receive_message()
+    # TODO: Get export method from message
     fbx_scene_loader.set_settings(commons.set_export_settings(settings_dict))
     fbx_scene_loader.export_all_objects(export_path)
     scene.info(f"File exported to {export_path}")

--- a/csc_files/externals/temp_importer.py
+++ b/csc_files/externals/temp_importer.py
@@ -22,10 +22,11 @@ def run(scene):
     except Exception as e:
         scene.error(f"Couldn't create socket. Error: {e}")
         return
-    file_path = client.receive_message()
-    # TODO: Get import method from message
-    # TODO: Get import method of fbx scene loader
-    fbx_scene_loader.import_model(file_path)
+    message: dict = client.receive_message()
+    file_path = message.get("file_path")
+
+    import_method = getattr(fbx_scene_loader, message.get("import_method"))
+    import_method(file_path)
     scene.info(f"File imported from {file_path}")
     client.send_message("SUCCESS")
     client.close()

--- a/csc_files/externals/temp_importer.py
+++ b/csc_files/externals/temp_importer.py
@@ -23,6 +23,8 @@ def run(scene):
         scene.error(f"Couldn't create socket. Error: {e}")
         return
     file_path = client.receive_message()
+    # TODO: Get import method from message
+    # TODO: Get import method of fbx scene loader
     fbx_scene_loader.import_model(file_path)
     scene.info(f"File imported from {file_path}")
     client.send_message("SUCCESS")

--- a/operators/addon_properties.py
+++ b/operators/addon_properties.py
@@ -7,6 +7,44 @@ def generate_items(options: list) -> list:
 
 
 class CBB_PG_fbx_settings(bpy.types.PropertyGroup):
+    import_method_items = [
+        (
+            "import_model",
+            "Model import",
+            "Importing fbx without animation data",
+        ),
+        (
+            "import_scene",
+            "Scene import",
+            "Importing fbx with animation data",
+        ),
+        (
+            "import_animation_to_selected_frames",
+            "To selected frames",
+            "Importing animation to the selected frames in Cascadeur",
+        ),
+        (
+            "import_animation_to_selected_objects",
+            "To selected objects",
+            "Importing animation to the selected objects in Cascadeur",
+        ),
+    ]
+
+    export_method_items = []  # TODO
+
+    # Cascadeur Import settings
+    cbb_csc_import_method: bpy.props.EnumProperty(
+        items=import_method_items,
+        name="Cascadeur Import Method",
+        description="Import method for Cascadeur fbx import",
+        default=config_handling.get_config_parameter(
+            "FBX Settings",
+            "cbb_csc_import_method",
+            str,
+            fallback="import_model",
+        ),
+    )
+
     # Cascadeur Export settings
     cbb_csc_apply_euler_filter: bpy.props.BoolProperty(
         name="Apply Euler Filter",

--- a/operators/addon_properties.py
+++ b/operators/addon_properties.py
@@ -7,45 +7,18 @@ def generate_items(options: list) -> list:
 
 
 class CBB_PG_fbx_settings(bpy.types.PropertyGroup):
-    import_method_items = [
-        (
-            "import_model",
-            "Model import",
-            "Importing fbx without animation data",
-        ),
-        (
-            "import_scene",
-            "Scene import",
-            "Importing fbx with animation data",
-        ),
-        (
-            "import_animation_to_selected_frames",
-            "To selected frames",
-            "Importing animation to the selected frames in Cascadeur",
-        ),
-        (
-            "import_animation_to_selected_objects",
-            "To selected objects",
-            "Importing animation to the selected objects in Cascadeur",
-        ),
-    ]
-
-    export_method_items = []  # TODO
-
-    # Cascadeur Import settings
-    cbb_csc_import_method: bpy.props.EnumProperty(
-        items=import_method_items,
-        name="Cascadeur Import Method",
-        description="Import method for Cascadeur fbx import",
+    # Cascadeur Export settings
+    cbb_csc_import_selected: bpy.props.BoolProperty(
+        name="Selected Interval",
+        description="Import selected interval only",
         default=config_handling.get_config_parameter(
             "FBX Settings",
-            "cbb_csc_import_method",
-            str,
-            fallback="import_model",
+            "cbb_csc_import_selected",
+            bool,
+            fallback=False,
         ),
     )
 
-    # Cascadeur Export settings
     cbb_csc_apply_euler_filter: bpy.props.BoolProperty(
         name="Apply Euler Filter",
         description="Automatically set objects' rotations to lowes possible values",
@@ -393,26 +366,64 @@ class CBB_PG_fbx_settings(bpy.types.PropertyGroup):
         ),
     )
 
+    cbb_export_methods: bpy.props.EnumProperty(
+        name="Cascadeur Export Method",
+        items=(
+            ("export_all_objects", "Export All Objects", ""),
+            ("export_joints", "Animation", ""),
+            ("export_joints_selected", "Animation - selected joints and frames", ""),
+            ("export_joints_selected_frames", "Animation - selected frames", ""),
+            ("export_joints_selected_objects", "Animation - selected joints", ""),
+            ("export_model", "Model", ""),
+            ("export_scene_selected", "Scene - selected objects and frames", ""),
+            ("export_scene_selected_frames", "Scene - selected frames", ""),
+            ("export_scene_selected_objects", "Scene - selected objects", ""),
+        ),
+        description="Method to use when exporting from Cascadeur",
+        default=config_handling.get_config_parameter(
+            "FBX Settings",
+            "cbb_export_methods",
+            set,
+            fallback={"export_all_objects"},
+        ),
+    )  # type: ignore
 
-def register_props() -> None:
+    cbb_import_methods: bpy.props.EnumProperty(
+        name="Cascadeur Export Method",
+        items=(
+            ("add_model", "Add Model", ""),
+            ("add_model_to_selected", "Add Model to Selected", ""),
+            ("import_animation", "Animation", ""),
+            ("import_animation_to_selected_frames", "Animation - selected frames", ""),
+            ("import_animation_to_selected_objects", "Animation - selected joints", ""),
+            ("import_model", "Model", ""),
+            ("import_scene", "Scene", ""),
+        ),
+        description="Method to use when exporting from Cascadeur",
+        default=config_handling.get_config_parameter(
+            "FBX Settings",
+            "cbb_import_methods",
+            set,
+            fallback={"import_model"},
+        ),
+    )  # type: ignore
+
+
+def register_props():
     bpy.utils.register_class(CBB_PG_fbx_settings)
     bpy.types.Scene.cbb_fbx_settings = bpy.props.PointerProperty(
         type=CBB_PG_fbx_settings
     )
 
 
-def unregister_props() -> None:
+def unregister_props():
     bpy.utils.unregister_class(CBB_PG_fbx_settings)
 
 
 def get_csc_export_settings() -> dict:
-    """
-    Collect Cascadeur FBX export settings in a dictionary.
-
-    :return dict: Cascadeur FBX export settings
-    """
     settings = {}
     addon_props = bpy.context.scene.cbb_fbx_settings
+    settings["selected_interval"] = addon_props.cbb_csc_import_selected
     settings["euler_filter"] = addon_props.cbb_csc_apply_euler_filter
     settings["up_axis"] = addon_props.cbb_csc_up_axis
     settings["bake_animation"] = addon_props.cbb_csc_bake_animation

--- a/operators/addon_properties.py
+++ b/operators/addon_properties.py
@@ -383,8 +383,8 @@ class CBB_PG_fbx_settings(bpy.types.PropertyGroup):
         default=config_handling.get_config_parameter(
             "FBX Settings",
             "cbb_export_methods",
-            set,
-            fallback={"export_all_objects"},
+            str,
+            fallback="export_all_objects",
         ),
     )  # type: ignore
 
@@ -403,8 +403,8 @@ class CBB_PG_fbx_settings(bpy.types.PropertyGroup):
         default=config_handling.get_config_parameter(
             "FBX Settings",
             "cbb_import_methods",
-            set,
-            fallback={"import_model"},
+            str,
+            fallback="import_model",
         ),
     )  # type: ignore
 
@@ -427,6 +427,7 @@ def get_csc_export_settings() -> dict:
     settings["euler_filter"] = addon_props.cbb_csc_apply_euler_filter
     settings["up_axis"] = addon_props.cbb_csc_up_axis
     settings["bake_animation"] = addon_props.cbb_csc_bake_animation
+    settings["export_method"] = addon_props.cbb_export_methods
     return settings
 
 

--- a/operators/fbx_transfer.py
+++ b/operators/fbx_transfer.py
@@ -163,7 +163,13 @@ class CBB_OT_export_blender_fbx(OperatorBaseClass):
         self.server_socket.run()
 
         if self.server_socket.client_socket:
-            self.server_socket.send_message(self.file_path)
+            addon_props = bpy.context.scene.cbb_fbx_settings
+            import_method_name = addon_props.cbb_import_methods
+            message = {
+                "file_path": self.file_path,
+                "import_method": import_method_name,
+            }
+            self.server_socket.send_message(message)
             response = self.server_socket.receive_message()
             if response == "SUCCESS":
                 print("File successfully imported to Cascadeur.")

--- a/ui/main_panel.py
+++ b/ui/main_panel.py
@@ -49,6 +49,8 @@ class CBB_PT_parent_panel(PanelBasics, bpy.types.Panel):
         row.label(text="Blender > Cascadeur")
         row.scale_y = 1.2
         row = col.row()
+        row.prop(addon_props, "cbb_import_methods")
+        row = col.row()
         row.prop(addon_props, "cbb_csc_import_method")
         row.scale_y = 1.2
         row = col.row()
@@ -61,7 +63,8 @@ class CBB_PT_parent_panel(PanelBasics, bpy.types.Panel):
         row = col.row()
         row.label(text="Cascadeur > Blender")
         row.scale_y = 1.2
-
+        row = col.row()
+        row.prop(addon_props, "cbb_import_methods")
         props = col.operator(
             "cbb.import_cascadeur_action",
             text="Import Action",

--- a/ui/main_panel.py
+++ b/ui/main_panel.py
@@ -19,6 +19,7 @@ class CBB_PT_parent_panel(PanelBasics, bpy.types.Panel):
 
     def draw(self, context):
         _ch = CascadeurHandler()
+        addon_props = context.scene.cbb_fbx_settings
         layout = self.layout
         col = layout.column(align=False)
         if not _ch.is_csc_exe_path_valid:
@@ -43,12 +44,15 @@ class CBB_PT_parent_panel(PanelBasics, bpy.types.Panel):
 
         # Blender to Cascadeur
         box = layout.box()
-        col = box.column(align=True)
+        col = box.column()
         row = col.row()
         row.label(text="Blender > Cascadeur")
         row.scale_y = 1.2
-
-        col.operator(
+        row = col.row()
+        row.prop(addon_props, "cbb_csc_import_method")
+        row.scale_y = 1.2
+        row = col.row()
+        row.operator(
             "cbb.export_blender_fbx", text="Export To Cascadeur", icon="EXPORT"
         )
         # Cascadeur to Blender

--- a/ui/main_panel.py
+++ b/ui/main_panel.py
@@ -50,8 +50,6 @@ class CBB_PT_parent_panel(PanelBasics, bpy.types.Panel):
         row.scale_y = 1.2
         row = col.row()
         row.prop(addon_props, "cbb_import_methods")
-        row = col.row()
-        row.prop(addon_props, "cbb_csc_import_method")
         row.scale_y = 1.2
         row = col.row()
         row.operator(
@@ -64,7 +62,7 @@ class CBB_PT_parent_panel(PanelBasics, bpy.types.Panel):
         row.label(text="Cascadeur > Blender")
         row.scale_y = 1.2
         row = col.row()
-        row.prop(addon_props, "cbb_import_methods")
+        row.prop(addon_props, "cbb_export_methods")
         props = col.operator(
             "cbb.import_cascadeur_action",
             text="Import Action",


### PR DESCRIPTION
Support the different export and import methods that Cascadeur provides (with/without animation, selection only, joints only, etc)